### PR TITLE
MG 2.0, re-render graphics on data change

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -4,8 +4,4 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 var app = new EmberAddon();
 
-app.import('bower_components/metrics-graphics/dist/metricsgraphics.css');
-app.import('bower_components/d3/d3.min.js');
-app.import('bower_components/metrics-graphics/dist/metricsgraphics.min.js');
-
 module.exports = app.toTree();

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -4,9 +4,8 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 var app = new EmberAddon();
 
-app.import('bower_components/metrics-graphics/css/metricsgraphics.css');
-app.import('bower_components/metrics-graphics/css/metricsgraphics-layout.css');
+app.import('bower_components/metrics-graphics/dist/metricsgraphics.css');
 app.import('bower_components/d3/d3.min.js');
-app.import('bower_components/metrics-graphics/js/metricsgraphics.min.js');
+app.import('bower_components/metrics-graphics/dist/metricsgraphics.min.js');
 
 module.exports = app.toTree();

--- a/app/components/data-graphic.js
+++ b/app/components/data-graphic.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   tagName: 'data-graphic',
 
-  didInsertElement: function() {
+  renderDataGraphic: function() {
     this._super.apply(this, arguments);
 
     MG.data_graphic({
@@ -73,6 +73,6 @@ export default Ember.Component.extend({
       binned:                   this.get('binned'),
       bins:                     this.get('bins')
     });
-  }
+  }.on('didInsertElement')
 
 });

--- a/app/components/data-graphic.js
+++ b/app/components/data-graphic.js
@@ -4,8 +4,6 @@ export default Ember.Component.extend({
   tagName: 'data-graphic',
 
   renderDataGraphic: function() {
-    this._super.apply(this, arguments);
-
     MG.data_graphic({
       inflator:                 this.get('inflator'),
       max_x:                    this.get('max_x'),
@@ -39,7 +37,7 @@ export default Ember.Component.extend({
       markers:                  this.get('markers'),
       max_data_size:            this.get('max_data_size'),
       point_size:               this.get('point_size'),
-      rollover_callback:        this.get('rollover_callback'),
+      mouseover:                this.get('mouseover'),
       show_confidence_band:     this.get('show_confidence_band'),
       show_rollover_text:       this.get('show_rollover_text'),
       target:                   "#" + this.get('elementId'),
@@ -73,6 +71,15 @@ export default Ember.Component.extend({
       binned:                   this.get('binned'),
       bins:                     this.get('bins')
     });
-  }.on('didInsertElement')
+    Ember.addObserver(this, 'data', this.dataPropertyDidChange);
+  }.on('didInsertElement'),
+
+  willDestroyElement: function() {
+    Ember.removeObserver(this, 'data', this.dataPropertyDidChange);
+  },
+
+  dataPropertyDidChange: function() {
+    this.renderDataGraphic();
+  }
 
 });

--- a/app/components/data-graphic.js
+++ b/app/components/data-graphic.js
@@ -6,7 +6,7 @@ export default Ember.Component.extend({
   didInsertElement: function() {
     this._super.apply(this, arguments);
 
-    data_graphic({
+    MG.data_graphic({
       inflator:                 this.get('inflator'),
       max_x:                    this.get('max_x'),
       max_y:                    this.get('max_y'),

--- a/bower.json
+++ b/bower.json
@@ -13,8 +13,5 @@
     "ember-qunit": "0.1.8",
     "ember-qunit-notifications": "0.0.4",
     "qunit": "~1.15.0"
-  },
-  "devDependencies": {
-    "metrics-graphics": "2.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,6 @@
     "qunit": "~1.15.0"
   },
   "devDependencies": {
-    "metrics-graphics": "*"
+    "metrics-graphics": "2.0.0"
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,10 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-metrics-graphics'
+  name: 'ember-metrics-graphics',
+  included: function(app) {
+    app.import('bower_components/metrics-graphics/dist/metricsgraphics.css');
+    app.import('bower_components/d3/d3.min.js');
+    app.import('bower_components/metrics-graphics/dist/metricsgraphics.js');
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-metrics-graphics",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "directories": {
     "doc": "doc",
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-metrics-graphics",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "directories": {
     "doc": "doc",
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-metrics-graphics",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "directories": {
     "doc": "doc",
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-metrics-graphics",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "directories": {
     "doc": "doc",
     "test": "tests"


### PR DESCRIPTION
Hi @jdjkelly,

I haven't spent time on the testing side of this PR, but I've been using your addon and had to improve a couple of bits:
- [x] Updated metrics-graphics to the 2.0.0 API
- [x] `{{data-graphic}}` component now rerenders when the `data` property changes, i.e., when a route reloads a new dataset from the server-side.

I'll keep adding tests in the upcoming weeks, and adding some bits of documentation to the `README.md` that I've found/learned when dealing with Ember addons.

Cheers,
Vicente.
